### PR TITLE
Add in urls to spec documents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.2)
+    wdm (0.1.1)
     yell (2.0.7)
 
 PLATFORMS
@@ -302,6 +303,7 @@ DEPENDENCIES
   rake
   rubocop
   tzinfo-data
+  wdm (~> 0.1.0)
 
 BUNDLED WITH
    1.16.1

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       # Page Variables
+      json_url: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/JSON-RPC.md 
       image: img/logo.png
       link_tweet: "Tweet to @TWITTERHANDLE"
       link_facebook: "Write on @FACEBOOKHANDLE's wall"

--- a/_data/blockchain.yml
+++ b/_data/blockchain.yml
@@ -66,6 +66,7 @@ rpc:
       bitprim: no
 
     - name: getmempoolentry
+      url: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/JSON-RPC.md#getmempoolentry-txid
       abc: yes
       bu: no
       xt: no
@@ -78,6 +79,7 @@ rpc:
       bitprim: no
 
     - name: getrawmempool
+      url: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/JSON-RPC.md#getrawmempool--verbose-
       abc: yes
       bu: yes
       xt: yes
@@ -120,6 +122,7 @@ rpc:
       bitprim: no
 
     - name: verifytxoutproof
+      url: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/JSON-RPC.md#verifytxoutproof-proof
       abc: no
       bu: yes
       xt: yes

--- a/_data/network.yml
+++ b/_data/network.yml
@@ -12,6 +12,7 @@ rpc:
       bitprim: no
 
     - name: disconnectnode
+      url: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/JSON-RPC.md#disconnectnode-address-nodeid
       abc: yes
       bu: yes
       xt: no

--- a/_data/sections.yml
+++ b/_data/sections.yml
@@ -28,12 +28,12 @@
   icon: exchange
   page: home
 
-- id: wallet
-  title: Wallet
-  icon: bitcoin
-  page: home
-
 - id: util
   title: Util
   icon: cogs
+  page: home
+
+- id: wallet
+  title: Wallet
+  icon: bitcoin
   page: home

--- a/_data/wallet.yml
+++ b/_data/wallet.yml
@@ -5,19 +5,7 @@ rpc:
       xt: no
       bitprim: yes
 
-    - name: getaddresstxids
-      abc: no
-      bu: no
-      xt: no
-      bitprim: yes
-
     - name: getaddressdeltas
-      abc: no
-      bu: no
-      xt: no
-      bitprim: yes
-
-    - name: getaddressutxos
       abc: no
       bu: no
       xt: no
@@ -28,3 +16,15 @@ rpc:
       bu: no
       xt: no
       bitprim: yes  
+
+    - name: getaddresstxids
+      abc: no
+      bu: no
+      xt: no
+      bitprim: yes
+
+    - name: getaddressutxos
+      abc: no
+      bu: no
+      xt: no
+      bitprim: yes

--- a/_includes/segment/table-row-title.html
+++ b/_includes/segment/table-row-title.html
@@ -11,6 +11,7 @@
 {%- endfor -%}
 {%- endif -%}
 </div>
-<a href="/" class="name" target="_blank" rel="noopener">{{ rpc.name }}</a>
+{%- assign url = rpc.url | default: '' -%}
+<a href="{% if url != '' %}{{url}}{% else %}{{ page.json_url | append: '#' | append: rpc.name }}{% endif %}" alt="{{rpc.name}}" class="name" target="_blank" rel="noopener">{{ rpc.name }}</a>
 {%- include exception.html website=rpc -%}
 </div>

--- a/rpc_schema.yml
+++ b/rpc_schema.yml
@@ -14,6 +14,12 @@ mapping:
             required: yes
             ident: yes
             unique: yes
+          "url":
+            type: str
+            desc: URL of site, must be in HTTP or HTTPS format
+            pattern: /^(https?:\/\/)([\da-zA-Z0-9\.-]+)\.([a-zA-Z0-9\.]{2,8})([\/\w \.-]*)*\/?.*$/
+            # required: yes
+            unique: yes
           "abc":
             type: bool
             required: yes


### PR DESCRIPTION
I fixed up urls where I could but some just dont line up to anything in the github doc on the specs...I have listed them below by section:

## Generating
- generate
- getgenerate 
- setgenerate 

## Mining 
- getblockversion
- getminercomment
- getminingmaxblock
- setblockversion
- setminercomment
- setminingmaxblock

## Network
- expedited
- gettrafficshaping
- pushtx
- settrafficshaping

## Wallet
- getaddressbalance
- getaddresstxids
- getaddressdeltas
- getaddressutxos
- getaddressmempool

## Util
- get
- getaddressforms
- getstat
- getstatlist
- log
- set
- validatechainhistory


Along with these, I have re-ordered some sections and section data to be alphabetical as per the `verify.rb` script warns